### PR TITLE
Bugfix: Fix Slack Timestamp showing NaN, Footer showing undefined

### DIFF
--- a/src/SlackCard.js
+++ b/src/SlackCard.js
@@ -257,7 +257,7 @@ class SlackCard extends React.Component {
       message.attachments == undefined ? message.ts : message.attachments[0].ts;
     msgTime = msgTime == undefined ? message.ts : msgTime;
 
-    return getRelativeTime(new Date(msgTime * 1000));
+    return getRelativeTime(new Date(msgTime * 1000)); // convert sec to ms for date obj
   }
 
   getCardHeader(index) {


### PR DESCRIPTION
#### What does this PR do?
Fixed bug in calculating the slack timestamp. Also fixed bug where after timestamp, footer would show undefined when posting gifs using right gif.
#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
Start the wallboard and check that the bugs mentioned above are fixed.
#### Screenshots
<!--(if appropriate)-->
Before:
<img width="866" alt="Screen Shot 2019-07-17 at 2 33 37 PM" src="https://user-images.githubusercontent.com/35464088/61413255-e5ca0800-a89f-11e9-8d1d-b89c3df3ed1c.png">
After:
<img width="865" alt="Screen Shot 2019-07-17 at 2 32 24 PM" src="https://user-images.githubusercontent.com/35464088/61413264-ec587f80-a89f-11e9-9775-dbbbe8c88816.png">



#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
