### PR TITLE
Bug-Fix: Fixed issues where refresh gives 404 error from nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,5 +5,6 @@ server {
 
     location / {
         root /usr/share/nginx/html/;
+        try_files $uri $uri/ /index.html?/$request_uri;
     }
 }


### PR DESCRIPTION
#### What does this PR do?
When navigating to a page other than `/` (such as `/tv/`) and refresh the page, nginx will give a 404 response. This PR fixes this bug by adding a line to `nginx.conf` which tells it to redirect back to index.html when trying to load something other than `/`. I believe this is needed since all of the routing is done in `index.html` through react-router.

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
- Export variables
- `make image GIT_BRANCH=<current_branch>`
- `docker run --rm -p 3000:3000 --name wallboard -d <image_id>`
- Mac: Open `0.0.0.0:3000` in browser and navigate to TV wallboard.
- Windows: Open `localhost:3000` in browser and navigate to TV wallboard.
- Linux: ???
- Refresh and verify no 404 errors occur


#### Screenshots
<!--(if appropriate)-->
What the error looked like:
<img width="2541" alt="Screen Shot 2019-07-18 at 12 40 57 PM" src="https://user-images.githubusercontent.com/35464088/61486865-58e38500-a959-11e9-8af1-51e2830b14b1.png">

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
