### PR TITLE
Cycling Slack Messages with Grow Effect!

### DIFF
--- a/src/SlackComponent.js
+++ b/src/SlackComponent.js
@@ -10,6 +10,7 @@ import Grow from "@material-ui/core/Grow";
 const TOKEN = process.env.SLACK_TOKEN;
 const CHANNEL = process.env.SLACK_CHANNEL;
 const MAX_MSGS = 10;
+const ROTATE_INTERVAL = minute;
 
 const styles = {
   CardContainer: {
@@ -84,7 +85,7 @@ class SlackComponent extends React.Component {
       () => this.checkRefresh(),
       minute
     );
-    this.rotateTimerIntervalID = setInterval(() => this.rotateTimer(), minute);
+    this.rotateTimerIntervalID = setInterval(() => this.rotateTimer(), ROTATE_INTERVAL);
   }
 
   // clean up intervals
@@ -203,7 +204,7 @@ class SlackComponent extends React.Component {
   //create state with a arraylist consisting of SlackCard component with unique keys/index up to MAX_MSGS.
   setSlackMsg() {
     let cardList = [];
-    for (var i = 0; i < MAX_MSGS; i++) {
+    for (let i = 0; i < MAX_MSGS; i++) {
       cardList.push(
         <SlackCard
           key={i}


### PR DESCRIPTION
#### What does this PR do?
Cycle through the slack messages with grow effect (on the very top one) so to provide more dynamic aspect to the slack channel component.
- Used Grow component from material ui library
- Used displayIndex which contains the sequentially increasing number array which rotate every minute; and such rotated displayIndex elements are used as a basis for rotating slack messages so that I don't have to rotate slack messages array itself!

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @bankent1 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
`yarn build` `yarn start`
and on website link `/tv`, enjoy the rotating slack messages happening every minute :)

#### Screenshots
<!--(if appropriate)-->
https://screencast-o-matic.com/watch/cqiF3HOO4H

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
