### PR TITLE
EVE-53: Added an I2O route to the wallboard

### DIFF
--- a/src/wallboards/Home.js
+++ b/src/wallboards/Home.js
@@ -8,6 +8,7 @@ import Button from "@material-ui/core/Button";
 import GSRWallboard from "./GSRWallboard";
 import TVWallboard from "./TVWallboard";
 import AirforceWallboard from "./AirforceWallboard";
+import I2OWallboard from "./I2OWallboard";
 
 const proxy = props => <Home {...props} />;
 
@@ -16,7 +17,8 @@ export const wallboards = [
   { path: "/", component: proxy, key: "Home" },
   { path: "/tv/", component: TVWallboard, key: "TV" },
   { path: "/airforce/", component: AirforceWallboard, key: "Airforce" },
-  { path: "/gsr/", component: GSRWallboard, key: "GSR" }
+  { path: "/gsr/", component: GSRWallboard, key: "GSR" },
+  { path: "/i2o/", component: I2OWallboard, key: "I2O" }
 ];
 
 const styles = {

--- a/src/wallboards/I2OWallboard.js
+++ b/src/wallboards/I2OWallboard.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class I2OWallboard extends React.Component {
+  render() {
+    return <div>I2O</div>;
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds an I2O route to the wallboard for future team specific components.

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
```yarn build```
```yarn start```
Check for the I2O wallboard button and verify it works.

#### Screenshots
<!--(if appropriate)-->
<img width="1923" alt="Screen Shot 2019-07-22 at 8 58 56 AM" src="https://user-images.githubusercontent.com/35464088/61648308-07423f80-ac64-11e9-9791-96501c68ab88.png">


#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
