### PR TITLE
Bug-Fix: Material Icons not found bug

### DIFF
--- a/src/components/Github.js
+++ b/src/components/Github.js
@@ -21,9 +21,9 @@ import { getRelativeTime, hour, time } from "../utils/TimeUtils";
 import makeTrashable from "trashable";
 import { addS } from "../utils/TimeUtils";
 
-import NeutralState from "@material-ui/icons/remove";
-import BadState from "@material-ui/icons/clear";
-import GoodState from "@material-ui/icons/done";
+import NeutralState from "@material-ui/icons/Remove";
+import BadState from "@material-ui/icons/Clear";
+import GoodState from "@material-ui/icons/Done";
 import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
 


### PR DESCRIPTION
#### What does this PR do?
Fixed bug where the material icons used in `Github.js` could not be found, leading to jenkins failing to build.
#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
```make image GIT_BRANCH=<branch_name>```
```docker run --rm -p 3000:3000 --name wallboard -d <image id>```

*Windows*: navigate to `localhost:3000`
*Mac*: navigate to `0.0.0.0:3000`
#### Screenshots
<!--(if appropriate)-->
<img width="789" alt="Screen Shot 2019-08-01 at 4 01 49 PM" src="https://user-images.githubusercontent.com/35464088/62332757-b73e5680-b475-11e9-9343-c7db2cbb652d.png">

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
