### PR TITLE
EVE68: Fixed error toggling build status

### DIFF
--- a/src/components/BuildStatus.js
+++ b/src/components/BuildStatus.js
@@ -33,6 +33,10 @@ const ButtonDefault = styled(Button)`
 const ButtonSelected = styled(Button)`
   float: right;
   text-decoration: underline ${CX_DARK_BLUE};
+
+  &:hover {
+    text-decoration: underline ${CX_DARK_BLUE};
+  }
 `;
 
 class BuildStatus extends React.Component {
@@ -91,6 +95,11 @@ class BuildStatus extends React.Component {
 
   toggle() {
     this.setState({ toggle: !this.state.toggle });
+    clearInterval(this.toggleId);
+    this.toggleId = setInterval(() => this.toggle(), TOGGLE_INTERVAL);
+  }
+
+  clearTimer() {
     clearInterval(this.toggleId);
     this.toggleId = setInterval(() => this.toggle(), TOGGLE_INTERVAL);
   }
@@ -168,13 +177,21 @@ class BuildStatus extends React.Component {
   buildButtons(toggle) {
     return toggle ? (
       <div>
-        <ButtonDefault onClick={this.toggle}>Last 5 Builds</ButtonDefault>
-        <ButtonSelected>Current Build</ButtonSelected>
+        <ButtonDefault onClick={this.toggle.bind(this)}>
+          Last 5 Builds
+        </ButtonDefault>
+        <ButtonSelected onClick={this.clearTimer.bind(this)}>
+          Current Build
+        </ButtonSelected>
       </div>
     ) : (
       <div>
-        <ButtonSelected>Last 5 Builds</ButtonSelected>
-        <ButtonDefault onClick={this.toggle}>Current Build</ButtonDefault>
+        <ButtonSelected onClick={this.clearTimer.bind(this)}>
+          Last 5 Builds
+        </ButtonSelected>
+        <ButtonDefault onClick={this.toggle.bind(this)}>
+          Current Build
+        </ButtonDefault>
       </div>
     );
   }


### PR DESCRIPTION
#### What does this PR do?

Fixed error when toggling build statuses.  Toggling build status now resets toggle interval & clicking currently selected button does not switch display.

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @bankent1 @alchucam @mcalcote @haydenudelson

#### How should this be tested?

`yarn go` and toggle build display to make sure it behaves as it should.

#### Screenshots

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
