### PR TITLE
EVE 66: allow PR builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,6 @@ pipeline {
       }
     }
     stage('Build Image') {
-      when {
-        allOf {
-          expression { env.CHANGE_ID == null }
-          expression { env.BRANCH_NAME == "master" || "DEV" }
-        }
-      }
       steps {
         withCredentials([
           string(credentialsId: 'SLACK_TOKEN', variable: 'SLACK_TOKEN'),


### PR DESCRIPTION
#### What does this PR do?
Now PR will be built by Jenkins so PR won't get a free highway Jenkins pass anymore

In the code, essentially two conditions has been removed
expression { env.CHANGE_ID == null }  : which is to run if it's not a PR
expression { env.BRANCH_NAME == "master" || "DEV" } : which is to run if it's a branch name of "master" or "DEV"
By removing these two conditions, everything will be build by Jenkins and be tested;
however, since the same conditions are remained the same in `Push Image` and `Deploy Marathon Service`, PR build will not have any impact to our actual web server.

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @Kjames5269 @bankent1 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
Once merged, check any PR build in Jenkins

#### Screenshots
<!--(if appropriate)-->

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
