### PR TITLE
Bug Fix: fixed broken DEV server due to port environment variable name

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,7 @@ const grafana = require("./grafana");
 
 dotenv.config();
 const app = express();
-const port = process.env.PORT || 3000;
+const port = process.env.EVE_PORT || 3000;
 const prod = process.env.NODE_ENV === "production";
 
 app.use(express.static("target"));


### PR DESCRIPTION
#### What does this PR do?
Fixed the port issue in Dev server due to the name of port environment variable.
![image](https://user-images.githubusercontent.com/40583917/62978249-aecf0f80-bdd5-11e9-88eb-b015ed65675b.png)
This is due to the existing port envar name in mesos, which our code picks it up instead of 3000.
DevOp team has set up an unique port envar name called EVE_PORT in dcos service to be 3000.

#### Who is reviewing it?
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin  @bankent1 @alchucam @mcalcote @haydenudelson

#### How should this be tested?
`make go`

#### Screenshots
<!--(if appropriate)-->

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
